### PR TITLE
remove comparing new truck drive state with previous one in order to …

### DIFF
--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/drivestate/TruckDriveStateController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/drivestate/TruckDriveStateController.kt
@@ -54,19 +54,6 @@ class TruckDriveStateController {
 
         val foundDriverId = truckDriveState.driverCardId?.let { userManagementService.findDriverByDriverCardId(it)?.id }
 
-        val latestRecord = truckDriveStateRepository.find(
-            "truck = :truck and timestamp <= :timestamp order by timestamp desc limit 1",
-            Parameters.with("truck", truckEntity).and("timestamp", truckDriveState.timestamp)
-        ).firstResult<TruckDriveStateEntity>().awaitSuspending()
-        if (latestRecord != null &&
-            latestRecord.timestamp!! < truckDriveState.timestamp &&
-            latestRecord.state == truckDriveState.state &&
-            truckDriveState.driverCardId == latestRecord.driverCardId &&
-            foundDriverId == latestRecord.driverId) {
-            logger.debug("Latest truck drive state $truckDriveState for truck with id ${truckEntity.id} was the same")
-            return null
-        }
-
         val createdDriveState = truckDriveStateRepository.create(
             id = UUID.randomUUID(),
             state = truckDriveState.state,

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckDriveStateTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckDriveStateTestIT.kt
@@ -40,8 +40,6 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
         it.setApiKey().trucks.createDriveState(truck.id!!, truckDriveStateData)
         // should be ignored because timestamp is same
         it.setApiKey().trucks.createDriveState(truck.id, truckDriveStateData.copy(state = TruckDriveStateEnum.REST))
-        // should be ignored because the latest drive state record is the same
-        it.setApiKey().trucks.createDriveState(truck.id, truckDriveStateData.copy(timestamp = now + 1))
 
         val createdTruckDriveStates = it.manager.trucks.listDriveStates(truck.id)
         assertEquals(1, createdTruckDriveStates.size)


### PR DESCRIPTION
…save drive state changes as is

https://github.com/Metatavu/vp-kuljetus-vehicle-management-service-api/issues/89