### PR TITLE
Feature 91 api key names

### DIFF
--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/rest/AbstractApi.kt
@@ -21,8 +21,11 @@ abstract class AbstractApi: WithCoroutineScope() {
     @ConfigProperty(name = "vp.env")
     private lateinit var environment: String
 
-    @ConfigProperty(name = "vp.vehiclemanagement.telematics.apiKey")
+    @ConfigProperty(name = "vp.vehiclemanagement.data-receiver.apiKey")
     lateinit var dataReceiverApiKeyValue: String
+
+    @ConfigProperty(name = "vp.vehiclemanagement.keycloak.apiKey")
+    lateinit var keycloakApiKeyValue: String
 
     @Inject
     private lateinit var jsonWebToken: JsonWebToken
@@ -61,6 +64,16 @@ abstract class AbstractApi: WithCoroutineScope() {
     protected val requestDataReceiverKey: String?
         get() {
             return headers.getHeaderString("X-DataReceiver-API-Key")
+        }
+
+    /**
+     * Returns request keycloak api key
+     *
+     * @return request keycloak api key
+     */
+    protected val requestKeycloakKey: String?
+        get() {
+            return headers.getHeaderString("X-Keycloak-API-Key")
         }
 
     /**

--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/rest/AbstractApi.kt
@@ -22,7 +22,7 @@ abstract class AbstractApi: WithCoroutineScope() {
     private lateinit var environment: String
 
     @ConfigProperty(name = "vp.vehiclemanagement.telematics.apiKey")
-    lateinit var apiKey: String
+    lateinit var dataReceiverApiKeyValue: String
 
     @Inject
     private lateinit var jsonWebToken: JsonWebToken
@@ -54,13 +54,13 @@ abstract class AbstractApi: WithCoroutineScope() {
         }
 
     /**
-     * Returns request api key
+     * Returns request data receiver api key
      *
-     * @return request api key
+     * @return request data receiver api key
      */
-    protected val requestApiKey: String?
+    protected val requestDataReceiverKey: String?
         get() {
-            return headers.getHeaderString("X-API-Key")
+            return headers.getHeaderString("X-DataReceiver-API-Key")
         }
 
     /**

--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
@@ -153,8 +153,11 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
    }
 
     // Driver cards
-    @RolesAllowed(DRIVER_ROLE)
     override fun listTruckDriverCards(truckId: UUID): Uni<Response> = withCoroutineScope {
+        if (loggedUserId == null && requestKeycloakKey == null) return@withCoroutineScope createUnauthorized(UNAUTHORIZED)
+        if (requestKeycloakKey != null && requestKeycloakKey != keycloakApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (loggedUserId != null && !hasRealmRole(DRIVER_ROLE)) return@withCoroutineScope createForbidden(FORBIDDEN)
+
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
 
         val (cards, count) = driverCardController.listDriverCards(truck)

--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
@@ -153,12 +153,8 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
    }
 
     // Driver cards
-
+    @RolesAllowed(DRIVER_ROLE)
     override fun listTruckDriverCards(truckId: UUID): Uni<Response> = withCoroutineScope {
-        if (loggedUserId == null && requestApiKey == null) return@withCoroutineScope createUnauthorized(UNAUTHORIZED)
-        if (requestApiKey != null && requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
-        if (loggedUserId != null && !hasRealmRole(DRIVER_ROLE)) return@withCoroutineScope createForbidden(FORBIDDEN)
-
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
 
         val (cards, count) = driverCardController.listDriverCards(truck)
@@ -167,7 +163,7 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
 
     @WithTransaction
     override fun createTruckDriverCard(truckId: UUID, truckDriverCard: TruckDriverCard): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDataReceiverKey != dataReceiverApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
         val driverCardWithId = driverCardController.findDriverCard(truckDriverCard.id)
         if (driverCardWithId != null && driverCardWithId.removedAt == null) {
             // Conflict if the card is already inserted in a truck and not removed
@@ -198,7 +194,7 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
         driverCardId: String,
         xRemovedAt: OffsetDateTime
     ): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDataReceiverKey != dataReceiverApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
         val insertedDriverCard = driverCardController.findDriverCard(driverCardId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(DRIVER_CARD, driverCardId))
         if (insertedDriverCard.truck.id != truck.id) {
@@ -226,7 +222,7 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
 
     @WithTransaction
     override fun createTruckSpeed(truckId: UUID, truckSpeed: TruckSpeed): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDataReceiverKey != dataReceiverApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
         truckSpeedController.createTruckSpeed(truck, truckSpeed)  ?: return@withCoroutineScope createAccepted(null)
         createCreated()
@@ -248,7 +244,7 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
 
     @WithTransaction
     override fun createTruckLocation(truckId: UUID, truckLocation: TruckLocation): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDataReceiverKey != dataReceiverApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
         truckLocationController.createTruckLocation(truck, truckLocation) ?: return@withCoroutineScope createAccepted(null)
         createCreated()
@@ -281,7 +277,7 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
 
     @WithTransaction
     override fun createDriveState(truckId: UUID, truckDriveState: TruckDriveState): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDataReceiverKey != dataReceiverApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
 
         truckDriveStateController.createDriveState(truck, truckDriveState) ?: return@withCoroutineScope createAccepted(null)

--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
@@ -261,19 +261,6 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
         createCreated()
     }
 
-    override fun createTruckOdometerReading(truckId: UUID, truckOdometerReading: TruckOdometerReading): Uni<Response> {
-        TODO("Not yet implemented")
-    }
-    override fun listTruckOdometerReadings(
-        truckId: UUID,
-        after: OffsetDateTime?,
-        before: OffsetDateTime?,
-        first: Int?,
-        max: Int?
-    ): Uni<Response> {
-        TODO("Not yet implemented")
-    }
-
     // Truck Drive State endpoints
 
     @RolesAllowed(MANAGER_ROLE, DRIVER_ROLE)
@@ -325,7 +312,7 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
 
     @WithTransaction
     override fun createTruckOdometerReading(truckId: UUID, truckOdometerReading: TruckOdometerReading): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDataReceiverKey != dataReceiverApiKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
 
         val truck = truckController.findTruck(truckId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(TRUCK, truckId))
         truckOdometerReadingController.createTruckOdometerReading(truck, truckOdometerReading) ?: return@withCoroutineScope createAccepted(null)

--- a/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/vehiclemanagement/trucks/TrucksApiImpl.kt
@@ -250,6 +250,19 @@ class TrucksApiImpl: TrucksApi, AbstractApi() {
         createCreated()
     }
 
+    override fun createTruckOdometerReading(truckId: UUID, truckOdometerReading: TruckOdometerReading): Uni<Response> {
+        TODO("Not yet implemented")
+    }
+    override fun listTruckOdometerReadings(
+        truckId: UUID,
+        after: OffsetDateTime?,
+        before: OffsetDateTime?,
+        first: Int?,
+        max: Int?
+    ): Uni<Response> {
+        TODO("Not yet implemented")
+    }
+
     // Truck Drive State endpoints
 
     @RolesAllowed(MANAGER_ROLE, DRIVER_ROLE)

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/DriverCardTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/DriverCardTestIT.kt
@@ -113,7 +113,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             driverCardId = cardId,
             removedAt = removedAt
         )
-        val truck1Cards = it.setApiKey().trucks.listDriverCards(truckId = truck.id)
+        val truck1Cards = it.driver.trucks.listDriverCards(truckId = truck.id)
         assertEquals(1, truck1Cards.size)
         val removedCard1 = truck1Cards.first()
         assertEquals(removedAt.toEpochSecond(), OffsetDateTime.parse(removedCard1.removedAt.toString()).toEpochSecond())
@@ -124,7 +124,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
                 timestamp = now.toEpochSecond()
             )
         )
-        val truck1CardsAfterReInsert = it.setApiKey().trucks.listDriverCards(truckId = truck.id)
+        val truck1CardsAfterReInsert = it.driver.trucks.listDriverCards(truckId = truck.id)
         assertEquals(1, truck1CardsAfterReInsert.size)
         assertNull(truck1CardsAfterReInsert.first().removedAt)
 
@@ -141,9 +141,9 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             )
         )
         // Check that cards at truck 1 are deleted
-        val truck1CardsAfterDeletion = it.setApiKey().trucks.listDriverCards(truckId = truck.id)
+        val truck1CardsAfterDeletion = it.driver.trucks.listDriverCards(truckId = truck.id)
         assertEquals(0, truck1CardsAfterDeletion.size)
-        val truck2Cards = it.setApiKey().trucks.listDriverCards(truckId = truck2.id)
+        val truck2Cards = it.driver.trucks.listDriverCards(truckId = truck2.id)
         assertEquals(1, truck2Cards.size)
     }
 
@@ -152,7 +152,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/driverCards",
             method = Method.POST,
-            header = "X-API-Key" to "test-api-key",
+            header = "X-DataReceiver-API-Key" to "test-api-key",
             basePath = ApiTestSettings.apiBasePath,
             body = jacksonObjectMapper().writeValueAsString(
                 TruckDriverCard(
@@ -205,7 +205,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         )
 
         it.setApiKey().trucks.deleteTruckDriverCard(truck.id, driverCard1.id)
-        val truckCards = it.setApiKey().trucks.listDriverCards(truck.id)
+        val truckCards = it.driver.trucks.listDriverCards(truck.id)
         assertEquals(1, truckCards.size)
         assertNotNull(truckCards.first().removedAt)
     }
@@ -226,7 +226,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/driverCards/{driverCardId}",
             method = Method.DELETE,
-            header = "X-API-Key" to "test-api-key",
+            header = "X-DataReceiver-API-Key" to "test-api-key",
             basePath = ApiTestSettings.apiBasePath
         )
             .path(InvalidValueTestScenarioPath(
@@ -279,21 +279,15 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             truckDriverCard = driverCardData2
         )
 
-        val list = it.setApiKey().trucks.listDriverCards(truck.id)
+        val list = it.driver.trucks.listDriverCards(truck.id)
         assertEquals(1, list.size)
         assertEquals(driverCardData.id, list[0].id)
 
-        val list2 = it.setApiKey().trucks.listDriverCards(truck2.id)
+        val list2 = it.driver.trucks.listDriverCards(truck2.id)
         assertEquals(1, list2.size)
         assertEquals(driverCardData2.id, list2[0].id)
 
-        it.setApiKey().trucks.assertListDriverCardsFail(UUID.randomUUID(), 404)
-
-        // Access rights
-        it.setApiKey("invalid").trucks.assertListDriverCardsFail(
-            truckId = truck.id,
-            expectedStatus = 403
-        )
+        it.driver.trucks.assertListDriverCardsFail(UUID.randomUUID(), 404)
     }
 
     @Test
@@ -301,7 +295,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/driverCards",
             method = Method.GET,
-            header = "X-API-Key" to "test-api-key",
+            header = "X-DataReceiver-API-Key" to "test-api-key",
             basePath = ApiTestSettings.apiBasePath
         )
             .path(InvalidValueTestScenarioPath(
@@ -348,8 +342,8 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         )
 
         Awaitility.await().atMost(Duration.ofMinutes(1)).until {
-            val truck1Cards = it.setApiKey().trucks.listDriverCards(truckId = truck1.id)
-            val truck2Cards = it.setApiKey().trucks.listDriverCards(truckId = truck2.id)
+            val truck1Cards = it.driver.trucks.listDriverCards(truckId = truck1.id)
+            val truck2Cards = it.driver.trucks.listDriverCards(truckId = truck2.id)
             (truck2Cards + truck1Cards).isEmpty()
         }
     }

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/DriverCardTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/DriverCardTestIT.kt
@@ -35,7 +35,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         val truck = it.manager.trucks.create(it.manager.vehicles)
         val now = OffsetDateTime.now()
         val driverWorkEventConsumer = MessagingClient.setConsumer<DriverWorkEventGlobalEvent>(RoutingKey.DRIVER_WORKING_STATE_CHANGE.name)
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck.id!!,
             truckDriverCard = TruckDriverCard(
                 id = driver1CardId,
@@ -51,7 +51,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         assertEquals(message.workEventType, WorkEventType.DRIVER_CARD_INSERTED)
         assertEquals(message.time.toEpochSecond(), now.toEpochSecond())
 
-        it.setApiKey().trucks.deleteTruckDriverCard(truck.id, driver1CardId, OffsetDateTime.now().minusDays(1))
+        it.setDataReceiverApiKey().trucks.deleteTruckDriverCard(truck.id, driver1CardId, OffsetDateTime.now().minusDays(1))
 
         val messages2 = driverWorkEventConsumer.consumeMessages(1)
 
@@ -72,35 +72,35 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             timestamp = OffsetDateTime.now().toEpochSecond()
         )
         val cardId = testCard.id
-        val created = it.setApiKey().trucks.createDriverCard(
+        val created = it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck.id!!,
             truckDriverCard = testCard
         )
         assertEquals(testCard.id, created.id)
 
         // Invalid access rights
-        it.setApiKey("invalid").trucks.assertCreateDriverCardFail(
+        it.setDataReceiverApiKey("invalid").trucks.assertCreateDriverCardFail(
             truckId = truck.id,
             truckDriverCard = testCard,
             expectedStatus = 403
         )
 
         // Cannot insert the same card into the truck where it currently is
-        it.setApiKey().trucks.assertCreateDriverCardFail(
+        it.setDataReceiverApiKey().trucks.assertCreateDriverCardFail(
             truckId = truck.id,
             truckDriverCard = testCard,
             expectedStatus = 409
         )
 
         // Cannot insert another card in a truck that already has a different card
-        it.setApiKey().trucks.assertCreateDriverCardFail(
+        it.setDataReceiverApiKey().trucks.assertCreateDriverCardFail(
             truckId = truck.id,
             truckDriverCard = TruckDriverCard("another card", OffsetDateTime.now().toEpochSecond()),
             expectedStatus = 409
         )
 
         // Cannot insert the card that is currently inserted into another truck
-        it.setApiKey().trucks.assertCreateDriverCardFail(
+        it.setDataReceiverApiKey().trucks.assertCreateDriverCardFail(
             truckId = truck2.id!!,
             truckDriverCard = testCard,
             expectedStatus = 409
@@ -108,7 +108,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
 
         // Remove and re-insert the card, checking that removedAt status was updated correctly
         val removedAt = OffsetDateTime.now().minusMinutes(1)
-        it.setApiKey().trucks.deleteTruckDriverCard(
+        it.setDataReceiverApiKey().trucks.deleteTruckDriverCard(
             truckId = truck.id,
             driverCardId = cardId,
             removedAt = removedAt
@@ -117,7 +117,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         assertEquals(1, truck1Cards.size)
         val removedCard1 = truck1Cards.first()
         assertEquals(removedAt.toEpochSecond(), OffsetDateTime.parse(removedCard1.removedAt.toString()).toEpochSecond())
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck.id,
             truckDriverCard = TruckDriverCard(
                 id = cardId,
@@ -129,11 +129,11 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         assertNull(truck1CardsAfterReInsert.first().removedAt)
 
         // Remove the card from a truck, insert it to another one, test that it is completely removed from the first truck
-        it.setApiKey().trucks.deleteTruckDriverCard(
+        it.setDataReceiverApiKey().trucks.deleteTruckDriverCard(
             truckId = truck.id,
             driverCardId = cardId
         )
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck2.id,
             truckDriverCard = TruckDriverCard(
                 id = cardId,
@@ -175,7 +175,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         val truck = it.manager.trucks.create(it.manager.vehicles)
         val truck2 = it.manager.trucks.create(Truck(plateNumber="0002", type = Truck.Type.TRUCK, vin = "0002"), it.manager.vehicles)
 
-        val driverCard1 = it.setApiKey().trucks.createDriverCard(
+        val driverCard1 = it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck.id!!,
             truckDriverCard = TruckDriverCard(
                 id = "driverCardId",
@@ -183,7 +183,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             )
         )
 
-        val driverCard2 = it.setApiKey().trucks.createDriverCard(
+        val driverCard2 = it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck2.id!!,
             truckDriverCard = TruckDriverCard(
                 id = "driverCardId2",
@@ -192,19 +192,19 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         )
 
         // Access rights
-        it.setApiKey("invalid").trucks.assertDeleteDriverCardFail(
+        it.setDataReceiverApiKey("invalid").trucks.assertDeleteDriverCardFail(
             truckId = truck.id,
             driverCardId = driverCard1.id,
             expectedStatus = 403
         )
         // wrong truck/driver card combination
-        it.setApiKey().trucks.assertDeleteDriverCardFail(
+        it.setDataReceiverApiKey().trucks.assertDeleteDriverCardFail(
             truckId = truck.id,
             driverCardId = driverCard2.id,
             expectedStatus = 404
         )
 
-        it.setApiKey().trucks.deleteTruckDriverCard(truck.id, driverCard1.id)
+        it.setDataReceiverApiKey().trucks.deleteTruckDriverCard(truck.id, driverCard1.id)
         val truckCards = it.driver.trucks.listDriverCards(truck.id)
         assertEquals(1, truckCards.size)
         assertNotNull(truckCards.first().removedAt)
@@ -218,7 +218,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             id = "driverCardId",
             timestamp = OffsetDateTime.now().toEpochSecond()
         )
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck.id!!,
             truckDriverCard = driverCardData
         )
@@ -265,7 +265,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             id = "driverCardId",
             timestamp = OffsetDateTime.now().toEpochSecond()
         )
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck.id!!,
             truckDriverCard = driverCardData
         )
@@ -274,7 +274,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             id = "driverCardId2",
             timestamp = OffsetDateTime.now().toEpochSecond()
         )
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck2.id!!,
             truckDriverCard = driverCardData2
         )
@@ -286,6 +286,9 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         val list2 = it.driver.trucks.listDriverCards(truck2.id)
         assertEquals(1, list2.size)
         assertEquals(driverCardData2.id, list2[0].id)
+
+        val truck1CardsBYKeycloak = it.setKeycloakApiKey().trucks.listDriverCards(truckId = truck.id)
+        assertEquals(1, truck1CardsBYKeycloak.size)
 
         it.driver.trucks.assertListDriverCardsFail(UUID.randomUUID(), 404)
     }
@@ -312,7 +315,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         val truck1 = it.manager.trucks.create(plateNumber = "01", vin = "01", vehiclesTestBuilderResource = it.manager.vehicles)
         val truck2 = it.manager.trucks.create(plateNumber = "02", vin = "02", vehiclesTestBuilderResource = it.manager.vehicles)
 
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck1.id!!,
             truckDriverCard = TruckDriverCard(
                 id = driver1CardId,
@@ -320,7 +323,7 @@ class DriverCardTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createDriverCard(
+        it.setDataReceiverApiKey().trucks.createDriverCard(
             truckId = truck2.id!!,
             truckDriverCard = TruckDriverCard(
                 id = driver2CardId,
@@ -329,13 +332,13 @@ class DriverCardTestIT : AbstractFunctionalTest() {
         )
 
         // remove both cards
-        it.setApiKey().trucks.deleteTruckDriverCard(
+        it.setDataReceiverApiKey().trucks.deleteTruckDriverCard(
             truckId = truck1.id!!,
             driverCardId = driver1CardId,
             removedAt = OffsetDateTime.now().minusDays(1)
         )
 
-        it.setApiKey().trucks.deleteTruckDriverCard(
+        it.setDataReceiverApiKey().trucks.deleteTruckDriverCard(
             truckId = truck2.id!!,
             driverCardId = driver2CardId,
             removedAt = OffsetDateTime.now().minusDays(1)

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TestBuilder.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TestBuilder.kt
@@ -1,6 +1,5 @@
 package fi.metatavu.vp.vehiclemanagement.test.functional
 
-import fi.metatavu.vp.vehiclemanagement.test.functional.auth.TestBuilderAuthentication
 import fi.metatavu.jaxrs.test.functional.builder.AbstractAccessTokenTestBuilder
 import fi.metatavu.jaxrs.test.functional.builder.AbstractTestBuilder
 import fi.metatavu.jaxrs.test.functional.builder.auth.AccessTokenProvider
@@ -8,6 +7,9 @@ import fi.metatavu.jaxrs.test.functional.builder.auth.AuthorizedTestBuilderAuthe
 import fi.metatavu.jaxrs.test.functional.builder.auth.KeycloakAccessTokenProvider
 import fi.metatavu.jaxrs.test.functional.builder.auth.NullAccessTokenProvider
 import fi.metatavu.vp.test.client.infrastructure.ApiClient
+import fi.metatavu.vp.vehiclemanagement.test.functional.auth.TestBuilderAuthentication
+import fi.metatavu.vp.vehiclemanagement.test.functional.settings.DefaultTestProfile.Companion.VEHICLE_MANAGEMENT_DATA_RECEIVER_API_KEY
+import fi.metatavu.vp.vehiclemanagement.test.functional.settings.DefaultTestProfile.Companion.VEHICLE_MANAGEMENT_KEYCLOAK_API_KEY
 import org.eclipse.microprofile.config.ConfigProvider
 
 /**
@@ -18,7 +20,7 @@ import org.eclipse.microprofile.config.ConfigProvider
  */
 class TestBuilder(private val config: Map<String, String>): AbstractAccessTokenTestBuilder<ApiClient>() {
 
-    var anon = TestBuilderAuthentication(this, NullAccessTokenProvider(), null)
+    var anon = TestBuilderAuthentication(this, NullAccessTokenProvider(), null, null)
     var user = createTestBuilderAuthentication(username = "user", password = "test")
     val driver = createTestBuilderAuthentication(username = "driver1", password = "test")
     val driver2 = createTestBuilderAuthentication(username = "driver2", password = "test")
@@ -28,18 +30,39 @@ class TestBuilder(private val config: Map<String, String>): AbstractAccessTokenT
         abstractTestBuilder: AbstractTestBuilder<ApiClient, AccessTokenProvider>,
         authProvider: AccessTokenProvider
     ): AuthorizedTestBuilderAuthentication<ApiClient, AccessTokenProvider> {
-        return TestBuilderAuthentication(this, authProvider, null)
+        return TestBuilderAuthentication(this, authProvider, null, null)
     }
 
     /**
-     * Returns authentication with api key
+     * Returns authentication with data receiver api key
      *
      * @param apiKey device key
      * @return authorized client
      */
-    fun setApiKey(apiKey: String? = null): TestBuilderAuthentication {
-        val key = apiKey ?: "test-api-key"
-        return TestBuilderAuthentication(this, NullAccessTokenProvider(), key)
+    fun setDataReceiverApiKey(apiKey: String? = null): TestBuilderAuthentication {
+        val key = apiKey ?: VEHICLE_MANAGEMENT_DATA_RECEIVER_API_KEY
+        return TestBuilderAuthentication(
+            this,
+            NullAccessTokenProvider(),
+            dataReceiverApiKey = key,
+            keycloakApiKey = null
+        )
+    }
+
+    /**
+     * Returns authentication with keycloak api key
+     *
+     * @param apiKey device key
+     * @return authorized client
+     */
+    fun setKeycloakApiKey(apiKey: String? = null): TestBuilderAuthentication {
+        val key = apiKey ?: VEHICLE_MANAGEMENT_KEYCLOAK_API_KEY
+        return TestBuilderAuthentication(
+            this,
+            NullAccessTokenProvider(),
+            keycloakApiKey = key,
+            dataReceiverApiKey = null
+        )
     }
     
     /**
@@ -53,7 +76,7 @@ class TestBuilder(private val config: Map<String, String>): AbstractAccessTokenT
         val serverUrl = ConfigProvider.getConfig().getValue("quarkus.oidc.auth-server-url", String::class.java).substringBeforeLast("/").substringBeforeLast("/")
         val realm = "vp-kuljetus"
         val clientId = "test"
-        return TestBuilderAuthentication(this, KeycloakAccessTokenProvider(serverUrl, realm, clientId, username, password, null), null)
+        return TestBuilderAuthentication(this, KeycloakAccessTokenProvider(serverUrl, realm, clientId, username, password, null), null, null)
     }
 
 }

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckDriveStateTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckDriveStateTestIT.kt
@@ -37,9 +37,9 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
             timestamp = now,
             driverCardId = driver1CardId,
         )
-        it.setApiKey().trucks.createDriveState(truck.id!!, truckDriveStateData)
+        it.setDataReceiverApiKey().trucks.createDriveState(truck.id!!, truckDriveStateData)
         // should be ignored because timestamp is same
-        it.setApiKey().trucks.createDriveState(truck.id, truckDriveStateData.copy(state = TruckDriveStateEnum.REST))
+        it.setDataReceiverApiKey().trucks.createDriveState(truck.id, truckDriveStateData.copy(state = TruckDriveStateEnum.REST))
 
         val createdTruckDriveStates = it.manager.trucks.listDriveStates(truck.id)
         assertEquals(1, createdTruckDriveStates.size)
@@ -57,7 +57,7 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
             assertEquals(WorkEventType.DRIVE, message.workEventType)
         }
 
-        it.setApiKey().trucks.createDriveState(
+        it.setDataReceiverApiKey().trucks.createDriveState(
             truck.id,
             truckDriveStateData.copy(state = TruckDriveStateEnum.REST, timestamp = now + 10_000)
         )
@@ -73,7 +73,7 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
     @Test
     fun testCreateTruckDriveStatesFail() = createTestBuilder().use {
         val truck = it.manager.trucks.create(it.manager.vehicles)
-        val driverCard = it.setApiKey().trucks.createDriverCard(truck.id!!, TruckDriverCard("driverCardId", OffsetDateTime.now().toEpochSecond()))
+        val driverCard = it.setDataReceiverApiKey().trucks.createDriverCard(truck.id!!, TruckDriverCard("driverCardId", OffsetDateTime.now().toEpochSecond()))
 
         val now = System.currentTimeMillis()
         val truckDriveStateData = TruckDriveState(
@@ -83,7 +83,7 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
         )
 
         // access rights
-        it.setApiKey("fake key").trucks.assertCreateDriveStateFail(truck.id, truckDriveStateData, 403)
+        it.setDataReceiverApiKey("fake key").trucks.assertCreateDriveStateFail(truck.id, truckDriveStateData, 403)
 
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/driveStates",
@@ -111,21 +111,21 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
 
         val now = OffsetDateTime.now()
 
-        it.setApiKey().trucks.createDriveState(
+        it.setDataReceiverApiKey().trucks.createDriveState(
             truck.id!!, TruckDriveState(
                 state = TruckDriveStateEnum.DRIVE,
                 timestamp = now.toEpochSecond(),
                 driverCardId = driver1CardId
             )
         )
-        it.setApiKey().trucks.createDriveState(
+        it.setDataReceiverApiKey().trucks.createDriveState(
             truck.id, TruckDriveState(
                 state = TruckDriveStateEnum.REST,
                 timestamp = now.plusMinutes(1).toEpochSecond(),
                 driverCardId = driver1CardId
             )
         )
-        it.setApiKey().trucks.createDriveState(
+        it.setDataReceiverApiKey().trucks.createDriveState(
             truck2.id!!, TruckDriveState(
                 state = TruckDriveStateEnum.REST,
                 timestamp = now.toEpochSecond() * 1000,

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckDriveStateTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckDriveStateTestIT.kt
@@ -88,7 +88,7 @@ class TruckDriveStateTestIT : AbstractFunctionalTest() {
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/driveStates",
             method = Method.POST,
-            header = "X-API-Key" to "test-api-key",
+            header = "X-DataReceiver-API-Key" to "test-api-key",
             basePath = ApiTestSettings.apiBasePath,
             body = jacksonObjectMapper().writeValueAsString(truckDriveStateData)
         )

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckLocationTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckLocationTestIT.kt
@@ -63,7 +63,7 @@ class TruckLocationTestIT : AbstractFunctionalTest() {
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/locations",
             method = Method.POST,
-            header = "X-API-Key" to "test-api-key",
+            header = "X-DataReceiver-API-Key" to "test-api-key",
             basePath = ApiTestSettings.apiBasePath,
             body = jacksonObjectMapper().writeValueAsString(truckLocationData)  // nothing to verify
         )

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckLocationTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckLocationTestIT.kt
@@ -32,11 +32,11 @@ class TruckLocationTestIT : AbstractFunctionalTest() {
             heading = 1.0,
             timestamp = now
         )
-        it.setApiKey().trucks.createTruckLocation(truck.id!!, truckLocationData)
+        it.setDataReceiverApiKey().trucks.createTruckLocation(truck.id!!, truckLocationData)
         // should be ignored because timestamp is same even if data is different
-        it.setApiKey().trucks.createTruckLocation(truck.id, truckLocationData.copy(heading = 2.0))
+        it.setDataReceiverApiKey().trucks.createTruckLocation(truck.id, truckLocationData.copy(heading = 2.0))
         // should be ignored because the latest location record is the same
-        it.setApiKey().trucks.createTruckLocation(truck.id, truckLocationData.copy(timestamp = now + 1))
+        it.setDataReceiverApiKey().trucks.createTruckLocation(truck.id, truckLocationData.copy(timestamp = now + 1))
 
         val locations = it.manager.trucks.listTruckLocations(truck.id)
         assertEquals(1, locations.size)
@@ -58,7 +58,7 @@ class TruckLocationTestIT : AbstractFunctionalTest() {
             heading = 1.0,
             timestamp = now
         )
-        it.setApiKey("fake key").trucks.assertCreateTruckLocationFail(truck.id!!, truckLocationData, 403)
+        it.setDataReceiverApiKey("fake key").trucks.assertCreateTruckLocationFail(truck.id!!, truckLocationData, 403)
 
         InvalidValueTestScenarioBuilder(
             path = "v1/trucks/{truckId}/locations",
@@ -83,7 +83,7 @@ class TruckLocationTestIT : AbstractFunctionalTest() {
         val truck = it.manager.trucks.create(it.manager.vehicles)
         val truck2 = it.manager.trucks.create("002", "002", null, it.manager.vehicles)
         val now = OffsetDateTime.now()
-        it.setApiKey().trucks.createTruckLocation(
+        it.setDataReceiverApiKey().trucks.createTruckLocation(
             truck.id!!, TruckLocation(
                 latitude = 1.0,
                 longitude = 1.0,
@@ -91,7 +91,7 @@ class TruckLocationTestIT : AbstractFunctionalTest() {
                 timestamp = now.toEpochSecond()
             )
         )
-        it.setApiKey().trucks.createTruckLocation(
+        it.setDataReceiverApiKey().trucks.createTruckLocation(
             truck.id, TruckLocation(
                 latitude = 2.0,
                 longitude = 2.0,
@@ -99,7 +99,7 @@ class TruckLocationTestIT : AbstractFunctionalTest() {
                 timestamp = now.plusMinutes(1).toEpochSecond()
             )
         )
-        it.setApiKey().trucks.createTruckLocation(
+        it.setDataReceiverApiKey().trucks.createTruckLocation(
             truck2.id!!, TruckLocation(
                 latitude = 1.0,
                 longitude = 1.0,

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckOdometerReadingTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckOdometerReadingTestIT.kt
@@ -33,22 +33,22 @@ class TruckOdometerReadingTestIT : AbstractFunctionalTest() {
             timestamp = time1,
             odometerReading = 1000
         )
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id!!,
             truckOdometerReading = truckOdometerReadingData
         )
         // should be ignored because timestamp is same
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id,
             truckOdometerReading = truckOdometerReadingData.copy(odometerReading = 1001)
         )
         // should be ignored because the latest odometer reading record is the same
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id,
             truckOdometerReading = truckOdometerReadingData.copy(timestamp = time2)
         )
         // should be created successfully
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id,
             truckOdometerReading = truckOdometerReadingData.copy(odometerReading = 1001, timestamp = time2)
         )
@@ -99,7 +99,7 @@ class TruckOdometerReadingTestIT : AbstractFunctionalTest() {
         )
 
         val now = OffsetDateTime.now()
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id!!,
             truckOdometerReading = TruckOdometerReading(
                 timestamp = now.toEpochSecond(),
@@ -107,7 +107,7 @@ class TruckOdometerReadingTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id,
             truckOdometerReading = TruckOdometerReading(
                 timestamp = now.plusMinutes(1).toEpochSecond(),
@@ -115,7 +115,7 @@ class TruckOdometerReadingTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck.id,
             truckOdometerReading = TruckOdometerReading(
                 timestamp = now.plusMinutes(2).toEpochSecond(),
@@ -123,7 +123,7 @@ class TruckOdometerReadingTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck2.id!!,
             truckOdometerReading = TruckOdometerReading(
                 timestamp = now.toEpochSecond(),
@@ -131,7 +131,7 @@ class TruckOdometerReadingTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckOdometerReading(
+        it.setDataReceiverApiKey().trucks.createTruckOdometerReading(
             truckId = truck2.id,
             truckOdometerReading = TruckOdometerReading(
                 timestamp = now.minusMinutes(1).toEpochSecond(),

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckSpeedTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckSpeedTestIT.kt
@@ -33,22 +33,22 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
             timestamp = time1,
             speed = 100.0f
         )
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id!!,
             truckSpeed = truckSpeedData
         )
         // should be ignored because timestamp is same
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id,
             truckSpeed = truckSpeedData.copy(speed = 101.0f)
         )
         // should be ignored because the latest speed record is the same
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id,
             truckSpeed = truckSpeedData.copy(timestamp = time2)
         )
         // should be created successfully
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id,
             truckSpeed = truckSpeedData.copy(speed = 101.0f, timestamp = time2)
         )
@@ -99,7 +99,7 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
         )
 
         val now = OffsetDateTime.now()
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id!!,
             truckSpeed = TruckSpeed(
                 timestamp = now.toEpochSecond(),
@@ -107,7 +107,7 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id,
             truckSpeed = TruckSpeed(
                 timestamp = now.plusMinutes(1).toEpochSecond(),
@@ -115,7 +115,7 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck.id,
             truckSpeed = TruckSpeed(
                 timestamp = now.plusMinutes(2).toEpochSecond(),
@@ -123,7 +123,7 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck2.id!!,
             truckSpeed = TruckSpeed(
                 timestamp = now.toEpochSecond(),
@@ -131,7 +131,7 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
             )
         )
 
-        it.setApiKey().trucks.createTruckSpeed(
+        it.setDataReceiverApiKey().trucks.createTruckSpeed(
             truckId = truck2.id,
             truckSpeed = TruckSpeed(
                 timestamp = now.minusMinutes(1).toEpochSecond(),

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckSpeedTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/TruckSpeedTestIT.kt
@@ -75,7 +75,7 @@ class TruckSpeedTestIT : AbstractFunctionalTest() {
             basePath = ApiTestSettings.apiBasePath,
             path = "/v1/trucks/{truckId}/speeds",
             method = Method.POST,
-            header = "X-API-Key" to "test-api-key",
+            header = "X-DataReceiver-API-Key" to "test-api-key",
             body = jacksonObjectMapper().writeValueAsString(truckSpeedData) // nothing to verify in truck body
         )
             .path(

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/auth/TestBuilderAuthentication.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/auth/TestBuilderAuthentication.kt
@@ -16,15 +16,16 @@ import fi.metatavu.vp.vehiclemanagement.test.functional.impl.*
  *
  * @param testBuilder test builder instance
  * @param accessTokenProvider access token provider
- * @param apiKey api key
+ * @param dataReceiverApiKey api key
  */
 class TestBuilderAuthentication(
     private val testBuilder: TestBuilder,
     val accessTokenProvider: AccessTokenProvider,
-    private val apiKey: String?
+    private val dataReceiverApiKey: String?,
+    private val keycloakApiKey: String?
     ): AccessTokenTestBuilderAuthentication<ApiClient>(testBuilder, accessTokenProvider) {
 
-    val trucks = TrucksTestBuilderResource(testBuilder, accessTokenProvider, this.apiKey, createClient(accessTokenProvider))
+    val trucks = TrucksTestBuilderResource(testBuilder, accessTokenProvider, this.dataReceiverApiKey, this.keycloakApiKey, createClient(accessTokenProvider))
     val publicTrucks = PublicTrucksTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val towables = TowablesTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val vehicles = VehiclesTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/impl/TrucksTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/impl/TrucksTestBuilderResource.kt
@@ -474,7 +474,7 @@ class TrucksTestBuilderResource(
 
     override fun getApi(): TrucksApi {
         if (apiKey != null) {
-            ApiClient.apiKey["X-API-Key"] = apiKey
+            ApiClient.apiKey["X-DataReceiver-API-Key"] = apiKey
         }
         ApiClient.accessToken = accessTokenProvider?.accessToken
         return TrucksApi(ApiTestSettings.apiBasePath)

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/impl/TrucksTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/impl/TrucksTestBuilderResource.kt
@@ -17,7 +17,8 @@ import java.util.*
 class TrucksTestBuilderResource(
     testBuilder: TestBuilder,
     private val accessTokenProvider: AccessTokenProvider?,
-    private val apiKey: String?,
+    private val dataReceiverApiKey: String?,
+    private val keycloakApiKey: String?,
     apiClient: ApiClient
 ) : ApiTestBuilderResource<Truck, ApiClient>(testBuilder, apiClient) {
 
@@ -527,8 +528,12 @@ class TrucksTestBuilderResource(
     }
 
     override fun getApi(): TrucksApi {
-        if (apiKey != null) {
-            ApiClient.apiKey["X-DataReceiver-API-Key"] = apiKey
+        if (dataReceiverApiKey != null) {
+            ApiClient.apiKey["X-DataReceiver-API-Key"] = dataReceiverApiKey
+        }
+
+        if (keycloakApiKey != null) {
+            ApiClient.apiKey["X-Keycloak-API-Key"] = keycloakApiKey
         }
         ApiClient.accessToken = accessTokenProvider?.accessToken
         return TrucksApi(ApiTestSettings.apiBasePath)

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/settings/DefaultTestProfile.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/settings/DefaultTestProfile.kt
@@ -30,8 +30,8 @@ class DefaultTestProfile: QuarkusTestProfile {
     }
 
     companion object {
-        const val VEHICLE_MANAGEMENT_DATA_RECEIVER_API_KEY = "test-api-key"
-        const val VEHICLE_MANAGEMENT_KEYCLOAK_API_KEY = "test-api-key"
+        const val VEHICLE_MANAGEMENT_DATA_RECEIVER_API_KEY = "test-data-receiver-api-key"
+        const val VEHICLE_MANAGEMENT_KEYCLOAK_API_KEY = "test-keycloak-api-key"
         const val EXCHANGE_NAME = "test-exchange"
     }
 }

--- a/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/settings/DefaultTestProfile.kt
+++ b/src/test/kotlin/fi/metatavu/vp/vehiclemanagement/test/functional/settings/DefaultTestProfile.kt
@@ -11,7 +11,8 @@ class DefaultTestProfile: QuarkusTestProfile {
 
     override fun getConfigOverrides(): MutableMap<String, String> {
         val config: MutableMap<String, String> = HashMap()
-        config["vp.vehiclemanagement.telematics.apiKey"] = VEHICLE_MANAGEMENT_TELEMATICS_API_KEY
+        config["vp.vehiclemanagement.data-receiver.apiKey"] = VEHICLE_MANAGEMENT_DATA_RECEIVER_API_KEY
+        config["vp.vehiclemanagement.keycloak.apiKey"] = VEHICLE_MANAGEMENT_KEYCLOAK_API_KEY
         config["clearOldRemovedDriverCards.gracePeriod.minutes"] = "30"
         config["clearOldRemovedDriverCards.every"] = "1s"
         config["clearOldRemovedDriverCards.delay"] = "1s"
@@ -29,7 +30,8 @@ class DefaultTestProfile: QuarkusTestProfile {
     }
 
     companion object {
-        const val VEHICLE_MANAGEMENT_TELEMATICS_API_KEY = "test-api-key"
+        const val VEHICLE_MANAGEMENT_DATA_RECEIVER_API_KEY = "test-api-key"
+        const val VEHICLE_MANAGEMENT_KEYCLOAK_API_KEY = "test-api-key"
         const val EXCHANGE_NAME = "test-exchange"
     }
 }


### PR DESCRIPTION
https://github.com/Metatavu/vp-kuljetus-vehicle-management-service-api/issues/91

Specs changes according to: https://github.com/Metatavu/vp-kuljetus-transport-management-specs/pull/140

- Removed generic x-api-key header
- new api keys:
VP_VEHICLEMANAGEMENT_DATA_RECEIVER_APIKEY for telematic endpoints (for data-receiver access)
VP_VEHICLEMANAGEMENT_KEYCLOAK_APIKEY for driver cards listing (for keycloak access)

**Contains** https://github.com/Metatavu/vp-kuljetus-vehicle-management-service-api/pull/94
